### PR TITLE
Enabled sharing when creating a ticket

### DIFF
--- a/frontend/components/ticket/TicketForm.vue
+++ b/frontend/components/ticket/TicketForm.vue
@@ -44,7 +44,7 @@
 
       <!-- Share with -->
       <div class="mb-4">
-        <edit-share-with :shared_with="shared_with" :errors="errors" class="mb-2 w-1/5"
+        <edit-share-with :shared_with="shared_with" :errors="errors" class="mb-2 w-1/5" :author="user" can_share="true"
                          :inbox_id="$route.params.inboxId" v-on:input="updateSharedWith"></edit-share-with>
       </div>
 


### PR DESCRIPTION
A prop was not given from the ticket form, resulting in a hidden sharing option. This fixes #371 