### PR TITLE
Removed the functionality of changing the role

### DIFF
--- a/backend/ticketvise/tests/inbox/test_users.py
+++ b/backend/ticketvise/tests/inbox/test_users.py
@@ -4,7 +4,7 @@ from ticketvise.tests.inbox.utils import InboxTestCase
 
 class UsersTest(InboxTestCase):
     data = {
-        "role": Role.MANAGER,
+        "is_assignable": False,
     }
 
     def edit_user(self):
@@ -16,8 +16,8 @@ class UsersTest(InboxTestCase):
         """
         self.client.force_authenticate(self.coordinator)
         self.assertEqual(self.edit_user().status_code, 200)
-        self.assertEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).role,
-                         self.data["role"])
+        self.assertEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).is_assignable,
+                         self.data["is_assignable"])
 
     def test_edit_user_as_invalid_coordinator(self):
         """
@@ -25,17 +25,17 @@ class UsersTest(InboxTestCase):
         """
         self.client.force_authenticate(self.coordinator_2)
         self.assertEqual(self.edit_user().status_code, 403)
-        self.assertNotEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).role,
-                            self.data["role"])
+        self.assertNotEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).is_assignable,
+                            self.data["is_assignable"])
 
     def test_edit_user_as_assistant(self):
         """
-        Test to verify a assistant is unable to edit a user.
+        Test to verify a assistant is able to edit a user.
         """
         self.client.force_authenticate(self.assistant)
         self.assertEqual(self.edit_user().status_code, 200)
-        self.assertEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).role,
-                            self.data["role"])
+        self.assertEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).is_assignable,
+                            self.data["is_assignable"])
 
     def test_edit_user_as_student(self):
         """
@@ -43,8 +43,8 @@ class UsersTest(InboxTestCase):
         """
         self.client.force_authenticate(self.student)
         self.assertEqual(self.edit_user().status_code, 403)
-        self.assertNotEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).role,
-                            self.data["role"])
+        self.assertNotEqual(UserInbox.objects.get(user_id=self.student.id, inbox__id=self.inbox.id).is_assignable,
+                            self.data["is_assignable"])
 
     def test_users(self):
         self.client.force_authenticate(self.coordinator)

--- a/backend/ticketvise/views/api/inbox.py
+++ b/backend/ticketvise/views/api/inbox.py
@@ -144,7 +144,7 @@ class InboxGuestsAPIView(ListAPIView):
 class UpdateUserInboxSerializer(ModelSerializer):
     class Meta:
         model = UserInbox
-        fields = ["role", "is_assignable"]
+        fields = ["is_assignable"]
 
 
 class UserInboxApiView(RetrieveUpdateDestroyAPIView):

--- a/frontend/components/inbox/User.vue
+++ b/frontend/components/inbox/User.vue
@@ -45,13 +45,8 @@
             <dt class="text-sm leading-5 font-medium text-gray-500">
               Role
             </dt>
-            <dd class="text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-              <select name="role" v-model="inbox_user.role"
-                      class="block appearance-none bg-white border border-gray-400 hover:border-gray-500 px-4 py-1 pr-8 rounded shadow-sm leading-tight focus:outline-none focus:shadow-outline">
-                <option v-for="role in roles" :value="role.key">
-                  {{ role.label }}
-                </option>
-              </select>
+            <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
+              {{ inbox_user.role_label }}
             </dd>
           </div>
           <div class="bg-white px-4 py-3 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 ">
@@ -110,20 +105,6 @@ export default {
   data() {
     return {
       inbox_user: null,
-      roles: [
-        {
-          "key": "GUEST",
-          "label": "Student"
-        },
-        {
-          "key": "AGENT",
-          "label": "Teaching Assistant"
-        },
-        {
-          "key": "MANAGER",
-          "label": "Coordinator"
-        }
-      ]
     }
   },
   mounted() {


### PR DESCRIPTION
This function is outdated, since the role will always be updated from canvas. Since assistants have the same functionality as the coordinator, upgrading a role is unnecessary. fixes #372 