### PR TITLE
Possible fix sharing, fix labels

### DIFF
--- a/backend/ticketvise/views/api/ticket.py
+++ b/backend/ticketvise/views/api/ticket.py
@@ -395,7 +395,7 @@ class TicketLabelSerializer(ModelSerializer):
 
 class TicketLabelApiView(UpdateAPIView):
     serializer_class = TicketLabelSerializer
-    permission_classes = [UserIsInboxStaffPermission]
+    permission_classes = [UserHasAccessToTicketPermission]
 
     def get_object(self):
         inbox = get_object_or_404(Inbox, pk=self.kwargs["inbox_id"])

--- a/backend/ticketvise/views/api/user.py
+++ b/backend/ticketvise/views/api/user.py
@@ -78,7 +78,7 @@ class UserRoleApiView(APIView):
         return JsonResponse(data, safe=False)
 
 
-class UserGetFromUsernameApiView(RetrieveUpdateAPIView):
+class UserGetFromUsernameApiView(RetrieveAPIView):
     permission_classes = [UserIsInInboxPermission]
     serializer_class = UserUsernameSerializer
 

--- a/backend/ticketvise/views/api/user.py
+++ b/backend/ticketvise/views/api/user.py
@@ -10,7 +10,7 @@ from ticketvise.models.inbox import Inbox
 from ticketvise.models.notification import Notification
 from ticketvise.models.user import User, Role, UserInbox
 from ticketvise.views.api import DynamicFieldsModelSerializer
-from ticketvise.views.api.security import UserIsInInboxPermission, UserIsSuperUserPermission, UserIsInboxStaffPermission
+from ticketvise.views.api.security import UserIsInInboxPermission, UserIsSuperUserPermission
 
 
 class UserSerializer(DynamicFieldsModelSerializer):

--- a/frontend/components/ticket/EditShareWith.vue
+++ b/frontend/components/ticket/EditShareWith.vue
@@ -73,7 +73,8 @@
         this.$emit("input", this.shared_with)
       },
       getUsername(username) {
-        axios.get("/api/inboxes/" + this.inbox_id + "/users/" + username).then(response => {
+        // Empty config to possibly fix the error that sharing does not work on the live version.
+        axios.get("/api/inboxes/" + this.inbox_id + "/users/" + username, {}).then(response => {
           this.usernameErrors = []
           // Check if user exists in array
           let index = this.shared_with.findIndex(user => user.id === response.data.id)


### PR DESCRIPTION
Students can now change the labels again. Passing an empty config as possible fix for sharing