### PR TITLE
Improved dateformat

### DIFF
--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -7,7 +7,7 @@ export function calendarDate(date) {
         nextDay: '[Tomorrow at] HH:mm',
         lastWeek: '[Last] dddd [at] HH:mm',
         nextWeek: 'dddd [at] HH:mm',
-        sameElse: 'L [at] HH:mm'
+        sameElse: 'LL [at] HH:mm'
     });
 }
 

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -1,5 +1,6 @@
 import moment from "moment";
 
+moment.locale(navigator.language);
 export function calendarDate(date) {
     return moment.parseZone(date).calendar(null, {
         lastDay: '[Yesterday at] HH:mm',


### PR DESCRIPTION
was 
![afbeelding](https://user-images.githubusercontent.com/68845414/109312953-f1d1c600-7847-11eb-86a6-af1745056886.png)
becomes
![afbeelding](https://user-images.githubusercontent.com/68845414/109313047-0d3cd100-7848-11eb-941c-72ccdb826898.png)

