### PR TITLE
Fixed: HTML in emails are not rendered - #257

### DIFF
--- a/backend/ticketvise/settings.py
+++ b/backend/ticketvise/settings.py
@@ -178,7 +178,7 @@ SMTP_INBOUND_PORT = os.getenv("SMTP_INBOUND_PORT", 2525)
 if SEND_MAIL:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 else:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 EMAIL_HOST = os.getenv("SMTP_OUTBOUND_HOST", "smtp.sendgrid.net")
 EMAIL_PORT = os.getenv("SMTP_OUTBOUND_PORT", 587)
 EMAIL_HOST_USER = os.getenv("SMTP_OUTBOUND_USER", "apikey")

--- a/backend/ticketvise/templates/email/comments.html
+++ b/backend/ticketvise/templates/email/comments.html
@@ -1,405 +1,502 @@
-
-    <!doctype html>
-    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-      <head>
-        <title>
-          <mj-raw>{{ title }}</mj-raw>
-        </title>
-        <!--[if !mso]><!-->
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <!--<![endif]-->
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style type="text/css">
-          #outlook a { padding:0; }
-          body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
-          table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
-          img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
-          p { display:block;margin:13px 0; }
-        </style>
-        <!--[if mso]>
-        <noscript>
-        <xml>
-        <o:OfficeDocumentSettings>
-          <o:AllowPNG/>
-          <o:PixelsPerInch>96</o:PixelsPerInch>
-        </o:OfficeDocumentSettings>
-        </xml>
-        </noscript>
-        <![endif]-->
-        <!--[if lte mso 11]>
-        <style type="text/css">
-          .mj-outlook-group-fix { width:100% !important; }
-        </style>
-        <![endif]-->
-        
-      <!--[if !mso]><!-->
-        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
-        <style type="text/css">
-          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
-        </style>
-      <!--<![endif]-->
-
-    
-        
+{% load custom_tags %}
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+      xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <title>
+        <mj-raw>{{ title }}</mj-raw>
+    </title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style type="text/css">
-      @media only screen and (min-width:480px) {
-        .mj-column-per-100 { width:100% !important; max-width: 100%; }
-      }
+        #outlook a {
+            padding: 0;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table, td {
+            border-collapse: collapse;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+        }
+    </style>
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:AllowPNG/>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+        .mj-outlook-group-fix {
+            width: 100% !important;
+        }
+    </style>
+    <![endif]-->
+
+    <!--[if !mso]><!-->
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+    </style>
+    <!--<![endif]-->
+
+
+    <style type="text/css">
+        @media only screen and (min-width: 480px) {
+            .mj-column-per-100 {
+                width: 100% !important;
+                max-width: 100%;
+            }
+        }
     </style>
     <style media="screen and (min-width:480px)">
-      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+        .moz-text-html .mj-column-per-100 {
+            width: 100% !important;
+            max-width: 100%;
+        }
     </style>
-    
-  
-        <style type="text/css">
-        
-        
 
-    @media only screen and (max-width:480px) {
-      table.mj-full-width-mobile { width: 100% !important; }
-      td.mj-full-width-mobile { width: auto !important; }
-    }
-  
-        </style>
-        
-        
-      </head>
-      <body style="word-spacing:normal;">
-        
-    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">
-      {{ title }}
+
+    <style type="text/css">
+
+
+        @media only screen and (max-width: 480px) {
+            table.mj-full-width-mobile {
+                width: 100% !important;
+            }
+
+            td.mj-full-width-mobile {
+                width: auto !important;
+            }
+        }
+
+    </style>
+
+
+</head>
+<body style="word-spacing:normal;">
+
+<div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">
+    {{ title }}
+</div>
+
+
+<div
+        style=""
+>
+
+
+    <!--[if mso | IE]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;"
+           width="600">
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+    <div style="margin:0px auto;max-width:600px;">
+
+        <table
+                align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+            <tbody>
+            <tr>
+                <td
+                        style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+
+                    <div
+                            class="mj-column-per-100 mj-outlook-group-fix"
+                            style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                    >
+
+                        <table
+                                border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                style="vertical-align:top;" width="100%"
+                        >
+                            <tbody>
+
+                            <tr>
+                                <td
+                                        align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <table
+                                            border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                            style="border-collapse:collapse;border-spacing:0px;"
+                                    >
+                                        <tbody>
+                                        <tr>
+                                            <td style="width:128px;">
+
+                                                <img
+                                                        height="auto" src="https://ticketvise.com/img/banner.png"
+                                                        style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                                        width="128"
+                                                />
+
+                                            </td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <p
+                                            style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:100%;"
+                                    >
+                                    </p>
+
+                                    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+                              </td></tr></table><![endif]-->
+
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <div
+                                            style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#1a202c;"
+                                    >{{ title }}</div>
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <p
+                                            style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:100%;"
+                                    >
+                                    </p>
+
+                                    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+                              </td></tr></table><![endif]-->
+
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <div
+                                            style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#1a202c;"
+                                    >
+                                        <mj-raw>{{ ticket.title }}</mj-raw>
+                                    </div>
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="left"
+                                        style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:4px;word-break:break-word;"
+                                >
+
+                                    <div
+                                            style="font-family:helvetica;font-size:12px ;line-height:1;text-align:left;color:#1a202c;"
+                                    >
+                                        <mj-raw>{{ ticket.author.get_full_name }} - {{ ticket.date_created }}</mj-raw>
+                                    </div>
+
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td
+                                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <div
+                                            style="font-family:helvetica;font-size:16px;line-height:1;text-align:left;color:#1a202c;"
+                                    >
+                                        <mj-raw>{{ ticket.content|convert_markdown }}</mj-raw>
+                                    </div>
+
+                                </td>
+                            </tr>
+
+                            </tbody>
+                        </table>
+
+                    </div>
+
+                    <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
     </div>
-  
-        
-      <div
-         style=""
-      >
-        
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    
-      
-      <div  style="margin:0px auto;max-width:600px;">
-        
-        <table
-           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-        >
-          <tbody>
-            <tr>
-              <td
-                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-              >
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-            
-      <div
-         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-      >
-        
-      <table
-         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-      >
-        <tbody>
-          
-              <tr>
-                <td
-                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <table
-         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-      >
-        <tbody>
-          <tr>
-            <td  style="width:128px;">
-              
-      <img
-         height="auto" src="https://ticketvise.com/img/banner.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="128"
-      />
-    
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <p
-         style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:100%;"
-      >
-      </p>
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
-</td></tr></table><![endif]-->
-    
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#1a202c;"
-      >{{ title }}</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <p
-         style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:100%;"
-      >
-      </p>
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 2px #dd6b20;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
-</td></tr></table><![endif]-->
-    
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#1a202c;"
-      ><mj-raw>{{ ticket.title }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:4px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:12px ;line-height:1;text-align:left;color:#1a202c;"
-      ><mj-raw>{{ ticket.author.get_full_name }} - {{ ticket.date_created }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:16px;line-height:1;text-align:left;color:#1a202c;"
-      ><mj-raw>{{ ticket.content }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-        </tbody>
-      </table>
-    
-      </div>
-    
-          <!--[if mso | IE]></td></tr></table><![endif]-->
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        
-      </div>
-    
-      
-      <!--[if mso | IE]></td></tr></table><![endif]-->
-    
+
+
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+
     {% for comment in comments %}
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#EDF2F7" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    
-      
-      <div  style="background:#EDF2F7;background-color:#EDF2F7;margin:0px auto;border-radius:5px;max-width:600px;">
-        
-        <table
-           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#EDF2F7;background-color:#EDF2F7;width:100%;border-radius:5px;"
-        >
-          <tbody>
+
+        <!--[if mso | IE]>
+        <table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation"
+               style="width:600px;" width="600" bgcolor="#EDF2F7">
             <tr>
-              <td
-                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-              >
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-            
-      <div
-         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-      >
-        
-      <table
-         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-      >
-        <tbody>
-          
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;padding-bottom:4px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:16px;line-height:1;text-align:left;color:#1a202c;"
-      ><mj-raw>{{ comment.author.get_full_name }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;padding-top:0px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#000000;"
-      ><mj-raw>{{ comment.date_created }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td
-                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <div
-         style="font-family:helvetica;font-size:14px;line-height:1;text-align:left;color:#1a202c;"
-      ><mj-raw>{{ comment.content }}</mj-raw></div>
-    
-                </td>
-              </tr>
-            
-        </tbody>
-      </table>
-    
-      </div>
-    
-          <!--[if mso | IE]></td></tr></table><![endif]-->
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        
-      </div>
-    
-      
-      <!--[if mso | IE]></td></tr></table><![endif]-->
-    
-    {% if not forloop.last %}
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    
-      
-      <div  style="margin:0px auto;max-width:600px;">
-        
-        <table
-           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-        >
-          <tbody>
-            <tr>
-              <td
-                 style="direction:ltr;font-size:0px;padding:20px 0;padding-top:0px;text-align:center;"
-              >
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr></tr></table><![endif]-->
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        
-      </div>
-    
-      
-      <!--[if mso | IE]></td></tr></table><![endif]-->
-    
-    {% endif %}{% endfor %}
-      
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    
-      
-      <div  style="margin:0px auto;max-width:600px;">
-        
-        <table
-           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-        >
-          <tbody>
-            <tr>
-              <td
-                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-              >
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-            
-      <div
-         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-      >
-        
-      <table
-         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-      >
-        <tbody>
-          
-              <tr>
-                <td
-                   align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
-                  
-      <table
-         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
-      >
-        <tbody>
-          <tr>
-            <td
-               align="center" bgcolor="#dd6b20" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#dd6b20;" valign="middle"
+                <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+        <div style="background:#EDF2F7;background-color:#EDF2F7;margin:0px auto;border-radius:5px;max-width:600px;">
+
+            <table
+                    align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                    style="background:#EDF2F7;background-color:#EDF2F7;width:100%;border-radius:5px;"
             >
-              <a
-                 href="{{ url }}" style="display:inline-block;background:#dd6b20;color:white;font-family:Helvetica;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank"
-              >
-                View ticket
-              </a>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    
+                <tbody>
+                <tr>
+                    <td
+                            style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                    >
+                        <!--[if mso | IE]>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+
+                        <div
+                                class="mj-column-per-100 mj-outlook-group-fix"
+                                style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                        >
+
+                            <table
+                                    border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                    style="vertical-align:top;" width="100%"
+                            >
+                                <tbody>
+
+                                <tr>
+                                    <td
+                                            align="left"
+                                            style="font-size:0px;padding:10px 25px;padding-bottom:4px;word-break:break-word;"
+                                    >
+
+                                        <div
+                                                style="font-family:helvetica;font-size:16px;line-height:1;text-align:left;color:#1a202c;"
+                                        >
+                                            <mj-raw>{{ comment.author.get_full_name }}</mj-raw>
+                                        </div>
+
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td
+                                            align="left"
+                                            style="font-size:0px;padding:10px 25px;padding-top:0px;word-break:break-word;"
+                                    >
+
+                                        <div
+                                                style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#000000;"
+                                        >
+                                            <mj-raw>{{ comment.date_created }}</mj-raw>
+                                        </div>
+
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td
+                                            align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                    >
+
+                                        <div
+                                                style="font-family:helvetica;font-size:14px;line-height:1;text-align:left;color:#1a202c;"
+                                        >
+                                            <mj-raw>{{ comment.content|convert_markdown }}</mj-raw>
+                                        </div>
+
+                                    </td>
+                                </tr>
+
+                                </tbody>
+                            </table>
+
+                        </div>
+
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+
+        </div>
+
+
+        <!--[if mso | IE]></td></tr></table><![endif]-->
+
+        {% if not forloop.last %}
+
+            <!--[if mso | IE]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation"
+                   style="width:600px;" width="600">
+                <tr>
+                    <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+            <div style="margin:0px auto;max-width:600px;">
+
+                <table
+                        align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                        style="width:100%;"
+                >
+                    <tbody>
+                    <tr>
+                        <td
+                                style="direction:ltr;font-size:0px;padding:20px 0;padding-top:0px;text-align:center;"
+                        >
+                            <!--[if mso | IE]>
+                            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                <tr></tr>
+                            </table><![endif]-->
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+
+            </div>
+
+
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+
+        {% endif %}{% endfor %}
+
+    <!--[if mso | IE]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;"
+           width="600">
+        <tr>
+            <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+    <div style="margin:0px auto;max-width:600px;">
+
+        <table
+                align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+            <tbody>
+            <tr>
+                <td
+                        style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="" style="vertical-align:top;width:600px;"><![endif]-->
+
+                    <div
+                            class="mj-column-per-100 mj-outlook-group-fix"
+                            style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                    >
+
+                        <table
+                                border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                style="vertical-align:top;" width="100%"
+                        >
+                            <tbody>
+
+                            <tr>
+                                <td
+                                        align="center" vertical-align="middle"
+                                        style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                                >
+
+                                    <table
+                                            border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                            style="border-collapse:separate;line-height:100%;"
+                                    >
+                                        <tbody>
+                                        <tr>
+                                            <td
+                                                    align="center" bgcolor="#dd6b20" role="presentation"
+                                                    style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#dd6b20;"
+                                                    valign="middle"
+                                            >
+                                                <a
+                                                        href="{{ url }}"
+                                                        style="display:inline-block;background:#dd6b20;color:white;font-family:Helvetica;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;"
+                                                        target="_blank"
+                                                >
+                                                    View ticket
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+
+                                </td>
+                            </tr>
+                            <!-- <mj-text align="center">
+                          You can reply directly to this ticket by replying to this email.
+                        </mj-text> -->
+                            </tbody>
+                        </table>
+
+                    </div>
+
+                    <!--[if mso | IE]></td></tr></table><![endif]-->
                 </td>
-              </tr>
-            <!-- <mj-text align="center">
-          You can reply directly to this ticket by replying to this email.
-        </mj-text> -->
-        </tbody>
-      </table>
-    
-      </div>
-    
-          <!--[if mso | IE]></td></tr></table><![endif]-->
-              </td>
             </tr>
-          </tbody>
+            </tbody>
         </table>
-        
-      </div>
-    
-      
-      <!--[if mso | IE]></td></tr></table><![endif]-->
-    
-    
-      </div>
-    
-      </body>
-    </html>
+
+    </div>
+
+
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+</div>
+
+</body>
+</html>
   

--- a/backend/ticketvise/templates/email/comments.html
+++ b/backend/ticketvise/templates/email/comments.html
@@ -257,7 +257,7 @@
                                     <div
                                             style="font-family:helvetica;font-size:16px;line-height:1;text-align:left;color:#1a202c;"
                                     >
-                                        <mj-raw>{{ ticket.content|convert_markdown }}</mj-raw>
+                                        <mj-raw>{{ ticket.content|convert_markdown_to_html }}</mj-raw>
                                     </div>
 
                                 </td>
@@ -353,7 +353,7 @@
                                         <div
                                                 style="font-family:helvetica;font-size:14px;line-height:1;text-align:left;color:#1a202c;"
                                         >
-                                            <mj-raw>{{ comment.content|convert_markdown }}</mj-raw>
+                                            <mj-raw>{{ comment.content|convert_markdown_to_html }}</mj-raw>
                                         </div>
 
                                     </td>

--- a/backend/ticketvise/templatetags/custom_tags.py
+++ b/backend/ticketvise/templatetags/custom_tags.py
@@ -9,5 +9,5 @@ register = template.Library()
 
 @register.filter(is_safe=True)
 @stringfilter
-def convert_markdown(value):
+def convert_markdown_to_html(value):
     return mark_safe(markdown.markdown(value))

--- a/backend/ticketvise/templatetags/custom_tags.py
+++ b/backend/ticketvise/templatetags/custom_tags.py
@@ -1,0 +1,13 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.safestring import mark_safe
+
+import markdown
+
+register = template.Library()
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def convert_markdown(value):
+    return mark_safe(markdown.markdown(value))

--- a/backend/ticketvise/tests/test_notifications.py
+++ b/backend/ticketvise/tests/test_notifications.py
@@ -3,7 +3,7 @@ Test Notifications
 -------------------------------
 This file tests the notification functionality on the website.
 """
-
+from django.core import mail
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -49,7 +49,7 @@ class NotificationsTestCase(TestCase):
         self.ticket = Ticket.objects.create(author=self.student, assignee=self.ta2,
                                             title="How to code?",
                                             inbox=self.inbox, content="wat is 1+1?")
-        self.comment = Comment.objects.create(ticket=self.ticket, author=self.ta2, content="Hello World")
+        self.comment = Comment.objects.create(ticket=self.ticket, author=self.ta2, content="# Hello World")
 
         self.ticket_2 = Ticket.objects.create(author=self.student, assignee=self.ta,
                                               title="How to code v2?",
@@ -224,6 +224,10 @@ class NotificationsTestCase(TestCase):
         self.assertEqual(mention_notification.content,
                          f"You have been mentioned by {comment.author.get_full_name()}")
         self.assertEqual(mention_notification.inbox, self.ticket.inbox)
+
+        # Checking if email is send and markdown content is converted to HTML
+        self.assertNotEqual(len(mail.outbox), 0)
+        self.assertInHTML('<h1>Hello World</h1>', mail.outbox[-1].alternatives[0][0])
 
     def test_getters_assigned_notifications(self):
         """


### PR DESCRIPTION
Negeer nog even de mega, unformated 'comments.html' file, wordt spoedig vervangen