### PR TITLE
Implemented attachments in timeline

### DIFF
--- a/backend/ticketvise/views/api/__init__.py
+++ b/backend/ticketvise/views/api/__init__.py
@@ -165,10 +165,14 @@ class LabelSerializer(ModelSerializer):
 
 class TicketAttachmentSerializer(DynamicFieldsModelSerializer):
     uploader = UserSerializer(read_only=True, fields=(["first_name", "last_name", "username", "avatar_url", "id"]))
+    file_size = serializers.SerializerMethodField()
 
     class Meta:
         model = TicketAttachment
-        fields = ["id", "file", "uploader", "date_created"]
+        fields = ["id", "file", "file_size", "uploader", "date_created"]
+
+    def get_file_size(self, obj):
+        return obj.file.size
 
 
 class RoleSerializer(serializers.BaseSerializer):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,12 +16,14 @@
         "prismjs": "^1.25.0",
         "register-service-worker": "^1.7.1",
         "vue": "^3.0.0",
+        "vue-easy-lightbox": "^1.2.4",
         "vue-router": "^4.0.0-0",
         "vue3-chart-v2": "^0.8.2",
         "vuedraggable": "^2.24.3",
         "vuex": "^4.0.0-0"
       },
       "devDependencies": {
+        "@tailwindcss/aspect-ratio": "^0.2.1",
         "@tailwindcss/forms": "^0.3.3",
         "@toast-ui/editor": "^3.1.0",
         "@toast-ui/editor-plugin-code-syntax-highlight": "^3.0.0",
@@ -3663,6 +3665,15 @@
       "resolved": "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz",
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
+    },
+    "node_modules/@tailwindcss/aspect-ratio": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
+      "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
+      }
     },
     "node_modules/@tailwindcss/forms": {
       "version": "0.3.3",
@@ -24413,6 +24424,17 @@
       "integrity": "sha512-HgR3gSmlnypNU+hlqoiRBJsnShXSoig4XTFNZiPlyVZBtkDZdfD884wTxz+GDJHzWLPtv4wnAyuO95UCsPbyoQ==",
       "dev": true
     },
+    "node_modules/vue-easy-lightbox": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vue-easy-lightbox/-/vue-easy-lightbox-1.2.4.tgz",
+      "integrity": "sha512-V3hCEb1vWvMw6hbEe8fHBXvCYg2t01qGzYfvyu+z7InQTEq+8T1yRXqDiDI2NFSIQuScldOESo6kNklf21GPtw==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-eslint-parser": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.6.0.tgz",
@@ -29499,6 +29521,13 @@
       "resolved": "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz",
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
+    },
+    "@tailwindcss/aspect-ratio": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
+      "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
+      "dev": true,
+      "requires": {}
     },
     "@tailwindcss/forms": {
       "version": "0.3.3",
@@ -46415,6 +46444,12 @@
       "resolved": "https://registry.npmjs.org/vue-cli-plugin-tailwind/-/vue-cli-plugin-tailwind-2.0.6.tgz",
       "integrity": "sha512-HgR3gSmlnypNU+hlqoiRBJsnShXSoig4XTFNZiPlyVZBtkDZdfD884wTxz+GDJHzWLPtv4wnAyuO95UCsPbyoQ==",
       "dev": true
+    },
+    "vue-easy-lightbox": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vue-easy-lightbox/-/vue-easy-lightbox-1.2.4.tgz",
+      "integrity": "sha512-V3hCEb1vWvMw6hbEe8fHBXvCYg2t01qGzYfvyu+z7InQTEq+8T1yRXqDiDI2NFSIQuScldOESo6kNklf21GPtw==",
+      "requires": {}
     },
     "vue-eslint-parser": {
       "version": "7.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,12 +19,14 @@
     "prismjs": "^1.25.0",
     "register-service-worker": "^1.7.1",
     "vue": "^3.0.0",
+    "vue-easy-lightbox": "^1.2.4",
     "vue-router": "^4.0.0-0",
     "vue3-chart-v2": "^0.8.2",
     "vuedraggable": "^2.24.3",
     "vuex": "^4.0.0-0"
   },
   "devDependencies": {
+    "@tailwindcss/aspect-ratio": "^0.2.1",
     "@tailwindcss/forms": "^0.3.3",
     "@toast-ui/editor": "^3.1.0",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^3.0.0",

--- a/frontend/src/components/tickets/ActivityFeed.vue
+++ b/frontend/src/components/tickets/ActivityFeed.vue
@@ -290,11 +290,7 @@ export default {
       return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i]
     },
     filterImages (files) {
-      const images = []
-      for (let i = 0; i < files.length; i++) {
-        if (['jpg', 'png'].includes(files[i].extension.toLowerCase())) images.push(files[i])
-      }
-      return images
+      return files.filter(file => ['jpg', 'png'].includes(file.extension.toLowerCase()))
     }
   },
   computed: {

--- a/frontend/src/components/tickets/ActivityFeed.vue
+++ b/frontend/src/components/tickets/ActivityFeed.vue
@@ -99,6 +99,48 @@
                 </div>
               </div>
             </template>
+            <template v-else-if="item.type === 'attachment'" condition="item.type === 'attachment'">
+              <div>
+                <div class="relative px-1">
+                  <div class="h-8 w-8 bg-gray-100 rounded-full ring-8 ring-white flex items-center justify-center">
+                    <DocumentIcon class="h-5 w-5 text-gray-500" aria-hidden="true"/>
+                  </div>
+                </div>
+              </div>
+              <div class="min-w-0 flex-1 py-0">
+                <div class="text-sm leading-8 text-gray-500">
+                  <span class="mr-0.5">
+                    <span class="font-medium text-gray-900">{{ item?.person?.name }}</span>
+                    {{ ' ' }}
+                    uploaded the following file{{ item?.attachment?.length > 1 ? 's' : '' }}
+                  </span>
+                  {{ ' ' }}
+                  <span class="mr-0.5" v-for="attachment in item.attachment" :key="attachment.name">
+                    <a :href="attachment.href" target="_blank">
+                      <chip class="max-w-xs">
+                        <span class="truncate leading-4">{{ attachment.name + '.' + attachment.extension }}</span>
+                      </chip>
+                    </a>
+                    {{ ' ' }}
+                  </span>
+                  <span class="whitespace-nowrap">{{ item.date }}</span>
+                </div>
+
+                <VueEasyLightbox scrollDisabled moveDisabled :imgs="filterImages(item.attachment).map(a => a.href)" :visible="item.visible" :index="item.index" @hide="item.visible = false" />
+                <ul role="list" class="mt-2 grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 md:grid-cols-4 lg:grid-cols-3 xl:grid-cols-4 xl:gap-x-8">
+                  <li v-for="(attachment, index) in filterImages(item.attachment)" :key="index">
+                    <button @click="item.index = index; item.visible = true" class="group block w-full aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
+                      <img :src="attachment.href" class="object-cover pointer-events-none" loading=lazy />
+                      <button type="button" class="absolute inset-0 focus:outline-none">
+                        <span class="sr-only">View details for {{ attachment.name }}</span>
+                      </button>
+                    </button>
+                    <p class="mt-2 block text-sm font-medium text-gray-900 truncate pointer-events-none">{{ attachment.name + '.' + attachment.extension }}</p>
+                    <p class="block text-sm font-medium text-gray-500 pointer-events-none">{{ readableBytes(attachment.size) }}</p>
+                  </li>
+                </ul>
+              </div>
+            </template>
           </div>
         </div>
       </li>
@@ -150,6 +192,8 @@
 
 <script>
 import axios from 'axios'
+import VueEasyLightbox from 'vue-easy-lightbox'
+
 import Chip from '@/components/chip/Chip'
 import TicketInput from '@/components/inputs/TicketInput'
 import TicketInputViewer from '@/components/inputs/TicketInputViewer'
@@ -158,6 +202,7 @@ import {
   ChatAltIcon,
   CheckCircleIcon,
   CollectionIcon,
+  DocumentIcon,
   TagIcon,
   UserCircleIcon as UserCircleIconSolid,
   ExclamationCircleIcon
@@ -188,11 +233,13 @@ export default {
     CheckCircleIcon,
     Chip,
     CollectionIcon,
+    DocumentIcon,
     TagIcon,
     UserCircleIconSolid,
     ExclamationCircleIcon,
     TicketInput,
-    TicketInputViewer
+    TicketInputViewer,
+    VueEasyLightbox
   },
   props: {
     ticket: {
@@ -235,6 +282,19 @@ export default {
       axios.patch(`/api/inboxes/${ inboxId }/tickets/${ ticketInboxId }/status/close`).then(() => {
         this.$emit('post')
       })
+    },
+    readableBytes (bytes) {
+      const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+      if (bytes === 0) return '0 Byte'
+      const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)))
+      return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i]
+    },
+    filterImages (files) {
+      const images = []
+      for (let i = 0; i < files.length; i++) {
+        if (['jpg', 'png'].includes(files[i].extension.toLowerCase())) images.push(files[i])
+      }
+      return images
     }
   },
   computed: {

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -208,7 +208,6 @@ export default {
           }
         })
         .then(async (response) => {
-          console.log(response.data)
           if (!store.getters.inbox(inboxId)) await store.dispatch('update_inboxes')
 
           store.commit('update_tickets', { inbox: inboxId, tickets: response.data })

--- a/frontend/src/views/Ticket.vue
+++ b/frontend/src/views/Ticket.vue
@@ -501,6 +501,26 @@ export default {
             }
           }))
 
+          /* Add the attachments to the activities timeline. */
+          this.ticket.activity.push(...response.data.ticket.attachments.map(attachment => {
+            return {
+              id: attachment.id,
+              date: this.date(attachment.date_created),
+              datetime: attachment.date_created,
+              person: { name: attachment.uploader.first_name + ' ' + attachment.uploader.last_name, href: '#' },
+              imageUrl: attachment.uploader.avatar_url,
+              attachment: [{
+                name: attachment.file.substring(attachment.file.lastIndexOf('/') + 1, attachment.file.lastIndexOf('.')),
+                extension: attachment.file.substring(attachment.file.lastIndexOf('.') + 1),
+                size: attachment.file_size,
+                href: attachment.file
+              }],
+              type: 'attachment',
+              visible: false,
+              index: 0
+            }
+          }))
+
           /* Sort the activities on date. */
           this.ticket.activity.sort((a, b) => moment(a.datetime).diff(moment(b.datetime)))
 
@@ -535,6 +555,7 @@ export default {
           lastActivity = activity
         } else if (lastActivity && moment(lastActivity.datetime).diff(moment(activity.datetime)) < time) {
           if (lastActivity.type === 'tags' && lastActivity.is_added === activity.is_added && lastActivity.person?.name === activity.person?.name) lastActivity.tags.push(activity.tags[0])
+          else if (lastActivity.type === 'attachment' && lastActivity.is_added === activity.is_added && lastActivity.person?.name === activity.person?.name) lastActivity.attachment.push(activity.attachment[0])
           else {
             newActivities.push(lastActivity)
             lastActivity = activity

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -32,6 +32,7 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/forms'),
-    require('@tailwindcss/line-clamp')
+    require('@tailwindcss/line-clamp'),
+    require('@tailwindcss/aspect-ratio')
   ]
 }


### PR DESCRIPTION
- Implemented showing the attachments directly in the ticket timeline
- Every attachment is shown as a chip that is clickable to open the file in a new tab
- A preview is shown for image attachments
- Clicking a preview opens a carrousel of the images directly in TicketVise using _vue-easy-lightbox_