### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate Short Git SHA
         id: git-sha7
-        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Deploy to Docker Swarm (development)
         uses: sagebind/docker-swarm-deploy-action@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate Short Git SHA
         id: git-sha7
-        run: echo "::set-output name=sha7::$(echo ${{ github.sha }} | cut -c1-7)"
+        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Deploy to Docker Swarm (development)
         uses: sagebind/docker-swarm-deploy-action@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate Short Git SHA
         id: git-sha7
-        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        run: echo "sha7=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Docker Swarm (development)
         uses: sagebind/docker-swarm-deploy-action@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


